### PR TITLE
Fix authorizer missing from container

### DIFF
--- a/addon/initializers/simple-token.js
+++ b/addon/initializers/simple-token.js
@@ -1,7 +1,9 @@
 import TokenAuthenticator from '../authenticators/token';
+import TokenAuthorizer from '../authorizers/token';
 
 export function initialize(application) {
   application.register('authenticator:token', TokenAuthenticator);
+  application.register('authorizer:token', TokenAuthorizer);
 }
 
 export default {


### PR DESCRIPTION
Using routes with authorization was failing because the container didn't
contain a definition for the factory. Adding the authorizer in the
initialization fixes this.

Fixes issue #6
