### PR TITLE
fix typeof check

### DIFF
--- a/addon/configuration.js
+++ b/addon/configuration.js
@@ -17,7 +17,7 @@ export default {
 
   load(config) {
     for (let property in this) {
-      if (this.hasOwnProperty(property) && Ember.typeOf(property) !== 'function') {
+      if (this.hasOwnProperty(property) && Ember.typeOf(this[property]) !== 'function') {
         this[property] = getWithDefault(config, property, DEFAULTS[property]);
       }
     }


### PR DESCRIPTION
Fixes the `Ember.typeOf` check. The `property` variable was always a string before since it was being assigned the property name not the property itself.

This caused the `load` property to be overridden which in return failed in acceptance tests since `load` was `undefined` by the 2nd time the app was started in the acceptance test.
