### PR TITLE
remove catch from authentication ajax call

### DIFF
--- a/addon/authenticators/token.js
+++ b/addon/authenticators/token.js
@@ -27,11 +27,6 @@ export default Base.extend({
     return get(this, 'ajax').post(this.serverTokenEndpoint, {
       contentType: 'application/json',
       data: JSON.stringify(data)
-    }).then((response) => {
-      return resolve(response);
-    }).catch((error) => {
-      Ember.Logger.warn(error);
-      return reject();
     });
   }
 });


### PR DESCRIPTION
Having the `catch` in here causes errors not to bubble, which is problematic when trying to handle different rejection scenarios (for eg. 403 vs 401 responses).

I think `catch` shouldn't be used here at all (let the user handle ajax rejections). Instead if we want to validate the response we could go the same route [other authenticators](https://github.com/simplabs/ember-simple-auth/blob/master/addon/authenticators/devise.js#L123) went and add a `validate` method in the future.
